### PR TITLE
Fix when reading "dict"-encoded groups

### DIFF
--- a/R/read_h5mu.R
+++ b/R/read_h5mu.R
@@ -158,7 +158,7 @@ read_group <- function(group, read_uns=FALSE) {
             return(read_dataframe(group))
         } else if (endsWith(encoding, "matrix")) {
             return(read_sparse_matrix(group))
-        } else if (!encoding %in% c("dict")) {
+        } else if (encoding != "dict") {
             # "dict" encoding is just a regular group of attributes and should 
             # be read as though there is no defined encoding
             warning("Unknown encoding ", encoding)

--- a/R/read_h5mu.R
+++ b/R/read_h5mu.R
@@ -158,7 +158,9 @@ read_group <- function(group, read_uns=FALSE) {
             return(read_dataframe(group))
         } else if (endsWith(encoding, "matrix")) {
             return(read_sparse_matrix(group))
-        } else {
+        } else if (!encoding %in% c("dict")) {
+            # "dict" encoding is just a regular group of attributes and should 
+            # be read as though there is no defined encoding
             warning("Unknown encoding ", encoding)
             if (!read_uns)
                 return(invisible(NULL))


### PR DESCRIPTION
Closes #2.

So it turns out this solution is super simple. If we encounter "dict" encoding it means we just use the normal mechanism for reading metadata.

Happy to create a test for this, but I would need to know how you want anndata files included in the repo in this case.